### PR TITLE
Make the toolchain a configurable input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: "Build projects using different modes [default: 'release']"
     required: true
     default: "release"
+  toolchain:
+    description: "Build projects using a different rust toolchain [default: 'stable']"
+    required: true
+    default: "stable"
   outDirectory:
     description: "The `out_dir` property configured in Dioxus.toml [default: 'dist']"
     required: true
@@ -28,7 +32,7 @@ runs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: ${{ inputs.toolchain }}
         profile: minimal
         target: wasm32-unknown-unknown
         override: true


### PR DESCRIPTION
Currently the toolchain is set to stable with no way to change it, but that breaks my build so changing it to be configurable (with stable as default) would be very nice