### PR TITLE
 The version in the README shouldn't have a leading 'v'

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Dioxus Deploy"
-        uses: DioxusLabs/deploy-action@v0.1.2
+        uses: DioxusLabs/deploy-action@0.1.2
 ```


### PR DESCRIPTION
I didn't intend to close #8 but I'm unable to reopen it so here's the same PR:

Copying the workflow YAML from the README fails as the versions published on GitHub Marketplace aren't prefixed with a 'v'. Because of #7 I only got it to compile by downgrading to v0.1.1, but prior to that it failed with 
```
Error: Unable to resolve action `dioxuslabs/deploy-action@v0.1.1`, unable to find version `v0.1.1`
```
and by looking at the [marketplace](https://github.com/marketplace/actions/dioxus-deploy) I realized it said to use
```
              - name: Dioxus Deploy
                uses: DioxusLabs/deploy-action@0.1.1
```
i.e. no 'v'.

I assume v0.1.2 will be published before this is merged so I didn't bother with that but the 'v' definitely has to go.